### PR TITLE
Fix for UnboundLocalError

### DIFF
--- a/PrimedRPA
+++ b/PrimedRPA
@@ -801,9 +801,8 @@ def CheckingAlignedOutputFile(AllParameter):
 			HomoDFInputIndexBlocks = [HDFLST[i:i + AllParameter.Threads] for i in range(0, len(HDFLST), AllParameter.Threads)]
 			MTDFOVI = list(zip([fastadict]*len(HomoDFInputIndexBlocks),HomoDFInputIndexBlocks))
 
-			if __name__ == '__main__':
-				with Pool(processes=AllParameter.Threads) as pool:
-					AlignedDFMultiThreadOupt = pool.starmap(CreatingInputHomologyDF,MTDFOVI)
+			with Pool(processes=AllParameter.Threads) as pool:
+				AlignedDFMultiThreadOupt = pool.starmap(CreatingInputHomologyDF,MTDFOVI)
 			MergedAlignedDF = pd.concat(AlignedDFMultiThreadOupt).reset_index().drop(['index'],axis=1)
 			MergedAlignedDF = MergedAlignedDF.sort_values(by=['Index_Pos'])
 			MergedAlignedDF.to_csv('{}_Alignment_Summary.csv'.format(AllParameter.RunID),index=None)
@@ -815,9 +814,8 @@ def CheckingAlignedOutputFile(AllParameter):
 												 [MergedAlignedDF]*len(HomoDFInputIndexBlocks),
 												 HomoDFInputIndexBlocks))
 
-		if __name__ == '__main__':
-			with Pool(processes=AllParameter.Threads) as pool:
-				PotentialPrimerProbeOut = pool.starmap(IndentifyingAndFilteringOligos,PrimerProbeCheckParallelInput)
+		with Pool(processes=AllParameter.Threads) as pool:
+			PotentialPrimerProbeOut = pool.starmap(IndentifyingAndFilteringOligos,PrimerProbeCheckParallelInput)
 
 
 		PassedOligos =  pd.concat(PotentialPrimerProbeOut).reset_index().drop(['index'],axis=1)
@@ -884,9 +882,8 @@ def CheckingAlignedOutputFile(AllParameter):
 												  [PPL]*len(PSST)))
 
 
-						if __name__ == '__main__':
-							with Pool(processes=AllParameter.Threads) as pool:
-								SuccessfulSets = pool.starmap(ComboIdentifyier,ComboSearchInput)
+						with Pool(processes=AllParameter.Threads) as pool:
+							SuccessfulSets = pool.starmap(ComboIdentifyier,ComboSearchInput)
 
 						TempOutputDF = pd.concat(SuccessfulSets)
 						FinalOutputDF = pd.concat([FinalOutputDF,TempOutputDF])
@@ -1043,4 +1040,5 @@ if (AllParameter.InputFileType == 'MS' and AllParameter.InputFile != 'NO') :
 
 
 # Run Primer, Probe Design process
-CheckingAlignedOutputFile(AllParameter)
+if __name__ == "__main__":
+	CheckingAlignedOutputFile(AllParameter)


### PR DESCRIPTION
In modern versions of Python 3, the multiprocessing library calls forked modules __mp_main__ instead of __main__, so mid-function if __name__ == __main__ checks failed, causing the following code to reference an undefined variable.

I believe this check should have always been outside function-scope, so I have moved it to the top level before function invocation to fix all instances of this problem.